### PR TITLE
Update Dictionary Methods to support Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ print(results)
 
 ``size`` : determine the number of results to return, like this:
 
-```python
+``python
 
 results = devless.size(3).get_data('service_name', 'service_table')
+
+``
 
 ``offset`` : Set step in data data to be sent back: 
 
@@ -50,19 +52,25 @@ results = devless.size(3).get_data('service_name', 'service_table')
 
 ``python
 
-results = devless.offset(2).size(6).get_data('service_name', 'service_table') ```
+results = devless.offset(2).size(6).get_data('service_name', 'service_table') 
+
+``
 
 ``where`` : Get data based where a key matches a certain value: 
 
-```python
+``python
 
-results = devless.where('name', 'edmond').get_data('service_name', 'service_table') ```
+results = devless.where('name', 'edmond').get_data('service_name', 'service_table') 
+
+``
 
 ``orderBy`` : Order incoming results in descending order based on a key 
 
 ``python
 
-results = devless.orderBy('name').get_data('service_name', 'service_table') ``
+results = devless.orderBy('name').get_data('service_name', 'service_table') 
+
+``
 
 
 ### To update data to table 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Allows you manage and administer your Devless service integrations in Python.
 
 In your project's python file, simply import the devless.py module
 
-`import Devless` 
+`import devless` 
 
 
 ## Getting started 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pass your Devless instance URL and token generated on your dashboard to the Sdk 
 
 ```python
 
-devless = devless.Sdk("http://example.herokuapp.com", "1234567abcdefghijklmnopqrst")
+devless = Sdk("http://example.herokuapp.com", "1234567abcdefghijklmnopqrst")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ In your project's python file, simply import the devless.py module
 
 ### To connect to the Devless instance 
 
+Pass your Devless instance URL and token generated on your dashboard to the Sdk object.
+
 ```python
 
-devless = Sdk("http://example.com", "1234567abcdefghijklmnopqrst")
+devless = Sdk("http://example.herokuapp.com", "1234567abcdefghijklmnopqrst")
 
 ```
 
@@ -24,7 +26,7 @@ devless = Sdk("http://example.com", "1234567abcdefghijklmnopqrst")
 
 data = {"name":"edmond"}
 results = devless.add_data('service_name', 'service_table', data)
-print results
+print(results)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,87 +1,104 @@
-DevlessTeam/DV-PY-SDK)
+# Devless Python SDK
+Allows you use python to manage and administer your Devless service integrations in Python.
+
 ## Install
 
-# DV-PY-SDK
-Official Devless py sdk
+In your project python file, simply import the devless.py module
 
-# Getting started 
+`import Devless` 
+
+
+## Getting started 
 
 ### To connect to the Devless instance 
 
-```
-
+```python
 
 devless = Sdk("http://example.com", "1234567abcdefghijklmnopqrst")
 
 ```
+
 ### To add data to table 
 
-```
+```python
+
 data = {"name":"edmond"}
-results = devless.addData('service_name', 'service_table', data)
+results = devless.add_data('service_name', 'service_table', data)
 print results
 
 ```
 
 ### To query data from the Devless instance 
 
-```
-results = devless.getData('service_name','service_table')
-print results
+```python
+
+results = devless.get_data('service_name','service_table')
+print(results)
 
 ```
-### Also you may filter your query with : 
+### Optional filters for your query : 
 
-``size`` : determine the number of results to return 
+``size`` : determine the number of results to return, like this:
 
-``` eg: results = devless.size(3).getData('service_name', 'service_table')
+```python
 
-``offset`` : Set step in data data to be sent back 
+results = devless.size(3).get_data('service_name', 'service_table')
 
-## NB: This is to be used in combination with size
+``offset`` : Set step in data data to be sent back: 
 
-`` eg: results = devless.offset(2).size(6).getData('service_name', 'service_table') ```
+#### NB: This is to be used in combination with size
 
-`` where `` : Get data based where a key matches a certain value 
+``python
 
-``` eg: results = devless.where('name', 'edmond').getData('service_name', 'service_table') ```
+results = devless.offset(2).size(6).get_data('service_name', 'service_table') ```
+
+``where`` : Get data based where a key matches a certain value: 
+
+```python
+
+results = devless.where('name', 'edmond').get_data('service_name', 'service_table') ```
 
 ``orderBy`` : Order incoming results in descending order based on a key 
 
-`` eg: results = devless.orderBy('name').getData('service_name', 'service_table') ``
+``python
+
+results = devless.orderBy('name').get_data('service_name', 'service_table') ``
 
 
 ### To update data to table 
 
-```
-results = devless.where('id',1).updateData('service_name', 'service_table', {'name':'edmond'})
+```python
 
-print results 
+results = devless.where('id',1).update_data('service_name', 'service_table', {'name':'edmond'})
+
+print(results) 
 
 ```
 
 ### To delete data from a Devless instance 
 
 ```
-results = devless.where('id',1).deleteData('service_name','service_table')
+results = devless.where('id',1).delete_data('service_name','service_table')
 
 ```
 
 ## Make a call to an Action Class 
 
-```
+```python
+
 results = devless.call('service_name','method_name', {})
 
-print results
+print(results)
 
 ```
 
 ## Authenticating with a Devless instance
 
-```
+```python
+
 token = devless.call('devless','login', {'email':'k@gmail.com', 'password':'password'});
 
-devless.setUserToken(token['payload']['result']);
+devless.set_user_token(token['payload']['result']);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Devless Python SDK
-Allows you use python to manage and administer your Devless service integrations in Python.
+Allows you manage and administer your Devless service integrations in Python.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -40,37 +40,37 @@ print(results)
 
 ``size`` : determine the number of results to return, like this:
 
-``python
+```python
 
 results = devless.size(3).get_data('service_name', 'service_table')
 
-``
+```
 
 ``offset`` : Set step in data data to be sent back: 
 
 #### NB: This is to be used in combination with size
 
-``python
+```python
 
 results = devless.offset(2).size(6).get_data('service_name', 'service_table') 
 
-``
+```
 
 ``where`` : Get data based where a key matches a certain value: 
 
-``python
+```python
 
 results = devless.where('name', 'edmond').get_data('service_name', 'service_table') 
 
-``
+```
 
 ``orderBy`` : Order incoming results in descending order based on a key 
 
-``python
+```python
 
 results = devless.orderBy('name').get_data('service_name', 'service_table') 
 
-``
+```
 
 
 ### To update data to table 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Allows you manage and administer your Devless service integrations in Python.
 
 ## Install
 
-In your project python file, simply import the devless.py module
+In your project's python file, simply import the devless.py module
 
 `import Devless` 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pass your Devless instance URL and token generated on your dashboard to the Sdk 
 
 ```python
 
-devless = Sdk("http://example.herokuapp.com", "1234567abcdefghijklmnopqrst")
+devless = devless.Sdk("http://example.herokuapp.com", "1234567abcdefghijklmnopqrst")
 
 ```
 

--- a/devless.py
+++ b/devless.py
@@ -26,17 +26,17 @@ class Sdk(object):
     def get_data(self, service, table):
         data   = {}
         params = self.payload['params'] if 'params' in self.payload else ''
-        def query_maker(params):
-            query_params = ''
+        def queryMaker(params):
+            queryParams = ''
             for key, value in params.items():
                 if(type(value) == list):
                     for key_word in value:
-                        query_params += "&{key}={key_word}".format(key=key, key_word=key_word)
+                        queryParams += "&{key}={key_word}".format(key=key, key_word=key_word)
                 else:
-                    query_params = "&{key}={value}{query_params}".format(key=key, value=value,
-                        query_params=query_params)
-            return query_params
-        query = query_maker(params) if params != None else ''    
+                    queryParams = "&{key}={value}{queryParams}".format(key=key, value=value,
+                        queryParams=queryParams)
+            return queryParams
+        query = queryMaker(params) if params != None else ''    
         sub_url = '/api/v1/service/{service}/db?table={table}{query}'.format(service=service, table=table, query=query)
         return self.request_processor(data, sub_url, 'GET')
     

--- a/devless.py
+++ b/devless.py
@@ -28,7 +28,7 @@ class Sdk(object):
         params = self.payload['params'] if 'params' in self.payload else ''
         def queryMaker(params):
             queryParams = ''
-            for key, value in params.iteritems():
+            for key, value in params.items():
                 if(type(value) == list):
                     for key_word in value:
                         queryParams += "&{key}={key_word}".format(key=key, key_word=key_word)

--- a/devless.py
+++ b/devless.py
@@ -4,100 +4,100 @@ import json
 
 class Sdk(object):
 
-	connection = {};
-	headers    = {};
-	payload    = {};
+    connection = {};
+    headers    = {};
+    payload    = {};
 
-	def __init__(self, instance_url, token):
-		self.payload['user_token'] = ''
-		self.payload['params'] = {}
-		self.connection['instance_url'] = instance_url
-		self.headers = {
-			    'content-type':  "application/json",
-			    'cache-control': "no-cache",
-			    'devless-token': token
-			    }
-   		
-	def addData(self, service, table, data):
-		data   = json.dumps({"resource": [ {'name':table,"field":[data] } ]})
-		subUrl = '/api/v1/service/{service}/db'.format(service=service)
-  		return self.request_processor(data, subUrl, 'POST')
+    def __init__(self, instance_url, token):
+        self.payload['user_token'] = ''
+        self.payload['params'] = {}
+        self.connection['instance_url'] = instance_url
+        self.headers = {
+                'content-type':  "application/json",
+                'cache-control': "no-cache",
+                'devless-token': token
+                }
+        
+    def addData(self, service, table, data):
+        data   = json.dumps({"resource": [ {'name':table,"field":[data] } ]})
+        subUrl = '/api/v1/service/{service}/db'.format(service=service)
+        return self.request_processor(data, subUrl, 'POST')
 
-	def getData(self, service, table):
-		data   = {}
-		params = self.payload['params'] if 'params' in self.payload else ''
-		def queryMaker(params):
-			queryParams = ''
-			for key, value in params.iteritems():
-				if(type(value) == list):
-					for key_word in value:
-						queryParams += "&{key}={key_word}".format(key=key, key_word=key_word)
-				else:
-					queryParams = "&{key}={value}{queryParams}".format(key=key, value=value,
-						queryParams=queryParams)
-			return queryParams
-		query = queryMaker(params) if params != None else ''	
-		subUrl = '/api/v1/service/{service}/db?table={table}{query}'.format(service=service, table=table, query=query)
-		return self.request_processor(data, subUrl, 'GET')
-	
-	def updateData(self, service, table, data):
-		params = self.payload['params']['where'][0]
-		data   = json.dumps({"resource":[{"name":table,"params":[{"where":params,"data":[data]}]}]})
-		subUrl = '/api/v1/service/{service}/db'.format(service=service)
-		return self.request_processor(data, subUrl, 'PATCH')
+    def getData(self, service, table):
+        data   = {}
+        params = self.payload['params'] if 'params' in self.payload else ''
+        def queryMaker(params):
+            queryParams = ''
+            for key, value in params.items():
+                if(type(value) == list):
+                    for key_word in value:
+                        queryParams += "&{key}={key_word}".format(key=key, key_word=key_word)
+                else:
+                    queryParams = "&{key}={value}{queryParams}".format(key=key, value=value,
+                        queryParams=queryParams)
+            return queryParams
+        query = queryMaker(params) if params != None else ''    
+        subUrl = '/api/v1/service/{service}/db?table={table}{query}'.format(service=service, table=table, query=query)
+        return self.request_processor(data, subUrl, 'GET')
+    
+    def updateData(self, service, table, data):
+        params = self.payload['params']['where'][0]
+        data   = json.dumps({"resource":[{"name":table,"params":[{"where":params,"data":[data]}]}]})
+        subUrl = '/api/v1/service/{service}/db'.format(service=service)
+        return self.request_processor(data, subUrl, 'PATCH')
 
-	def deleteData(self, service, table):
-		params = self.payload['params']['where'][0]
-		data   = json.dumps({"resource":[{"name":table,"params":[{"where":params,"delete":"true"}]}]})
-		subUrl = '/api/v1/service/{service}/db'.format(service=service)
-		return self.request_processor(data, subUrl, 'DELETE')
+    def deleteData(self, service, table):
+        params = self.payload['params']['where'][0]
+        data   = json.dumps({"resource":[{"name":table,"params":[{"where":params,"delete":"true"}]}]})
+        subUrl = '/api/v1/service/{service}/db'.format(service=service)
+        return self.request_processor(data, subUrl, 'DELETE')
 
-	def call(self, service, method, params={}):
-		call_id = random.randint(1, 200000)
-		params  = json.dumps({ "jsonrpc":"2.0","method":service,"id":call_id,"params":params})
-		subUrl = "/api/v1/service/{service}/rpc?action={method}".format(service=service, method=method)
-		return self.request_processor(params, subUrl, 'POST')
+    def call(self, service, method, params={}):
+        call_id = random.randint(1, 200000)
+        params  = json.dumps({ "jsonrpc":"2.0","method":service,"id":call_id,"params":params})
+        subUrl = "/api/v1/service/{service}/rpc?action={method}".format(service=service, method=method)
+        return self.request_processor(params, subUrl, 'POST')
 
-	def setUserToken(self, token):
-		self.headers['devless-user-token'] = token
-		return self 
+    def setUserToken(self, token):
+        self.headers['devless-user-token'] = token
+        return self 
 
-	def where(self, column, value):
-		param = "{column},{value}".format(column=column, value=value)
-		self.bindToParams('where', param)
-		return self
+    def where(self, column, value):
+        param = "{column},{value}".format(column=column, value=value)
+        self.bindToParams('where', param)
+        return self
 
-	def offset(self, value):
-		self.bindToParams('offset', value)
-		return self
+    def offset(self, value):
+        self.bindToParams('offset', value)
+        return self
 
-	def orderBy(self, value):
-		self.bindToParams('orderBy', value)
-		return self
+    def orderBy(self, value):
+        self.bindToParams('orderBy', value)
+        return self
 
-	def size(self, value):
-		self.bindToParams('size', value)
-		return self
+    def size(self, value):
+        self.bindToParams('size', value)
+        return self
 
-	def bindToParams(self, methodName, args):
-		if methodName == 'where':
-			self.payload['params'][methodName] =  [] if not methodName in self.payload['params'] else self.payload['params'][methodName]
-			self.payload['params'][methodName].append(args)
-		else:
-			self.payload['params'][methodName] = None if methodName in self.payload['params'] else ''
-			self.payload['params'][methodName] = args;
+    def bindToParams(self, methodName, args):
+        if methodName == 'where':
+            self.payload['params'][methodName] =  [] if not methodName in self.payload['params'] else self.payload['params'][methodName]
+            self.payload['params'][methodName].append(args)
+        else:
+            self.payload['params'][methodName] = None if methodName in self.payload['params'] else ''
+            self.payload['params'][methodName] = args;
 
-	def seq_iter(self, obj):
-	    return obj if isinstance(obj, list) else iteritems(obj)		
+    def seq_iter(self, obj):
+        return obj if isinstance(obj, list) else iter(obj)     
 
-	def request_processor(self, data, subUrl, method):
-		url = "{instance_url}{subUrl}".format(
-			instance_url = self.connection['instance_url'], subUrl
-			= subUrl)
-		response = requests.request(method,
-		 url, data=data, headers=self.headers)
-		output_text = response.text
-		start  = output_text.find('{')
-		end    = output_text.rfind('}')
-		json_output = output_text[start:end+1] if start is not -1 or end is not -1 else output_text
-		return json.loads(json_output)
+    def request_processor(self, data, subUrl, method):
+        url = "{instance_url}{subUrl}".format(
+            instance_url = self.connection['instance_url'], subUrl
+            = subUrl)
+        response = requests.request(method,
+         url, data=data, headers=self.headers)
+        output_text = response.text
+        start  = output_text.find('{')
+        end    = output_text.rfind('}')
+        json_output = output_text[start:end+1] if start is not -1 or end is not -1 else output_text
+        return json.loads(json_output)

--- a/devless.py
+++ b/devless.py
@@ -26,17 +26,17 @@ class Sdk(object):
     def get_data(self, service, table):
         data   = {}
         params = self.payload['params'] if 'params' in self.payload else ''
-        def queryMaker(params):
-            queryParams = ''
+        def query_maker(params):
+            query_params = ''
             for key, value in params.items():
                 if(type(value) == list):
                     for key_word in value:
-                        queryParams += "&{key}={key_word}".format(key=key, key_word=key_word)
+                        query_params += "&{key}={key_word}".format(key=key, key_word=key_word)
                 else:
-                    queryParams = "&{key}={value}{queryParams}".format(key=key, value=value,
-                        queryParams=queryParams)
-            return queryParams
-        query = queryMaker(params) if params != None else ''    
+                    query_params = "&{key}={value}{query_params}".format(key=key, value=value,
+                        query_params=query_params)
+            return query_params
+        query = query_maker(params) if params != None else ''    
         sub_url = '/api/v1/service/{service}/db?table={table}{query}'.format(service=service, table=table, query=query)
         return self.request_processor(data, sub_url, 'GET')
     

--- a/devless.py
+++ b/devless.py
@@ -18,17 +18,17 @@ class Sdk(object):
                 'devless-token': token
                 }
         
-    def addData(self, service, table, data):
+    def add_data(self, service, table, data):
         data   = json.dumps({"resource": [ {'name':table,"field":[data] } ]})
-        subUrl = '/api/v1/service/{service}/db'.format(service=service)
-        return self.request_processor(data, subUrl, 'POST')
+        sub_url = '/api/v1/service/{service}/db'.format(service=service)
+        return self.request_processor(data, sub_url, 'POST')
 
-    def getData(self, service, table):
+    def get_data(self, service, table):
         data   = {}
         params = self.payload['params'] if 'params' in self.payload else ''
         def queryMaker(params):
             queryParams = ''
-            for key, value in params.items():
+            for key, value in params.iteritems():
                 if(type(value) == list):
                     for key_word in value:
                         queryParams += "&{key}={key_word}".format(key=key, key_word=key_word)
@@ -37,63 +37,63 @@ class Sdk(object):
                         queryParams=queryParams)
             return queryParams
         query = queryMaker(params) if params != None else ''    
-        subUrl = '/api/v1/service/{service}/db?table={table}{query}'.format(service=service, table=table, query=query)
-        return self.request_processor(data, subUrl, 'GET')
+        sub_url = '/api/v1/service/{service}/db?table={table}{query}'.format(service=service, table=table, query=query)
+        return self.request_processor(data, sub_url, 'GET')
     
-    def updateData(self, service, table, data):
+    def update_data(self, service, table, data):
         params = self.payload['params']['where'][0]
         data   = json.dumps({"resource":[{"name":table,"params":[{"where":params,"data":[data]}]}]})
-        subUrl = '/api/v1/service/{service}/db'.format(service=service)
-        return self.request_processor(data, subUrl, 'PATCH')
+        sub_url = '/api/v1/service/{service}/db'.format(service=service)
+        return self.request_processor(data, sub_url, 'PATCH')
 
-    def deleteData(self, service, table):
+    def delete_data(self, service, table):
         params = self.payload['params']['where'][0]
         data   = json.dumps({"resource":[{"name":table,"params":[{"where":params,"delete":"true"}]}]})
-        subUrl = '/api/v1/service/{service}/db'.format(service=service)
-        return self.request_processor(data, subUrl, 'DELETE')
+        sub_url = '/api/v1/service/{service}/db'.format(service=service)
+        return self.request_processor(data, sub_url, 'DELETE')
 
     def call(self, service, method, params={}):
         call_id = random.randint(1, 200000)
         params  = json.dumps({ "jsonrpc":"2.0","method":service,"id":call_id,"params":params})
-        subUrl = "/api/v1/service/{service}/rpc?action={method}".format(service=service, method=method)
-        return self.request_processor(params, subUrl, 'POST')
+        sub_url = "/api/v1/service/{service}/rpc?action={method}".format(service=service, method=method)
+        return self.request_processor(params, sub_url, 'POST')
 
-    def setUserToken(self, token):
+    def set_user_token(self, token):
         self.headers['devless-user-token'] = token
         return self 
 
     def where(self, column, value):
         param = "{column},{value}".format(column=column, value=value)
-        self.bindToParams('where', param)
+        self.bind_to_params('where', param)
         return self
 
     def offset(self, value):
-        self.bindToParams('offset', value)
+        self.bind_to_params('offset', value)
         return self
 
-    def orderBy(self, value):
-        self.bindToParams('orderBy', value)
+    def order_by(self, value):
+        self.bind_to_params('order_by', value)
         return self
 
     def size(self, value):
-        self.bindToParams('size', value)
+        self.bind_to_params('size', value)
         return self
 
-    def bindToParams(self, methodName, args):
-        if methodName == 'where':
-            self.payload['params'][methodName] =  [] if not methodName in self.payload['params'] else self.payload['params'][methodName]
-            self.payload['params'][methodName].append(args)
+    def bind_to_params(self, method_name, args):
+        if method_name == 'where':
+            self.payload['params'][method_name] =  [] if not method_name in self.payload['params'] else self.payload['params'][method_name]
+            self.payload['params'][method_name].append(args)
         else:
-            self.payload['params'][methodName] = None if methodName in self.payload['params'] else ''
-            self.payload['params'][methodName] = args;
+            self.payload['params'][method_name] = None if method_name in self.payload['params'] else ''
+            self.payload['params'][method_name] = args;
 
     def seq_iter(self, obj):
         return obj if isinstance(obj, list) else iter(obj)     
 
-    def request_processor(self, data, subUrl, method):
-        url = "{instance_url}{subUrl}".format(
-            instance_url = self.connection['instance_url'], subUrl
-            = subUrl)
+    def request_processor(self, data, sub_url, method):
+        url = "{instance_url}{sub_url}".format(
+            instance_url = self.connection['instance_url'], sub_url
+            = sub_url)
         response = requests.request(method,
          url, data=data, headers=self.headers)
         output_text = response.text


### PR DESCRIPTION
The method .iteritems() and function iteritems() have both been replaced with
.items() and iter() in the SDK respectively. The former was deprecated
in Python 3 and replaced with .items() which returns an iterable object
rather than a list. The latter was simply updated as it was not found in
the Python 2 or 3 documentation.